### PR TITLE
docs: update banner to just point to slack

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
 
 {% block announce %}
-<p>Join us for an <a href="https://community.cncf.io/events/details/cncf-cncf-online-programs-presents-cncf-on-demand-webinar-cloud-custodian-proactive-governance-of-your-cloud-cluster-and-code/">on demand webinar</a> with the CNCF on February 2nd!</p>
+<p>Join us <a href="https://communityinviter.com/apps/cloud-custodian/c7n-chat">on Slack</> to meet other people in the community!</p>
 {% endblock %}


### PR DESCRIPTION
This event is over so just reverting to a stock "join us on slack". This should be the default unless there's an event. When we have confirmation of booth stuff for KubeCon EU we'll update it again.